### PR TITLE
Introduce the "plone:static" directive (from plone.resource) before using it

### DIFF
--- a/beyondskins/responsive/configure.zcml
+++ b/beyondskins/responsive/configure.zcml
@@ -2,6 +2,8 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone">
 
+    <include package="plone.resource" file="meta.zcml"/>
+
     <plone:static 
             name="beyondskins.responsive"
             directory="theme/beyondskins.responsive" 


### PR DESCRIPTION
As per the note on http://pypi.python.org/pypi/plone.resource#files-in-python-distributions, this line is needed before using plone:static:

```
<include package="plone.resource" file="meta.zcml"/>
```

I'm running tests in my policy product to check beyondskins.responsive is installed. My tests fail without this line :-(
